### PR TITLE
Fix for issue #14: New Account Welcome Email

### DIFF
--- a/Brewgr.Web/Brewgr.Web.csproj
+++ b/Brewgr.Web/Brewgr.Web.csproj
@@ -222,6 +222,7 @@
     <Compile Include="Email\DefaultEmailMessageFactory.cs" />
     <Compile Include="Email\EmailMessageType.cs" />
     <Compile Include="Email\IEmailMessageFactory.cs" />
+    <Compile Include="Email\NewAccountEmailMessage.cs" />
     <Compile Include="Email\PasswordResetEmailMessage.cs" />
     <Compile Include="Email\RecipeCommentEmailMessage.cs" />
     <Compile Include="Global.asax.cs">

--- a/Brewgr.Web/Controllers/AuthController.cs
+++ b/Brewgr.Web/Controllers/AuthController.cs
@@ -136,9 +136,13 @@ namespace Brewgr.Web.Controllers
 				var user = this.UserService.RegisterNewUser(signUpViewModel.NewUserFullName, signUpViewModel.NewUserEmailAddress, signUpViewModel.NewUserPassword);
 				unitOfWork.Commit();
 
-				// TODO: We need to send a welcome email
+                // Send the Email Message
+                var newAccountEmailMessage = (NewAccountEmailMessage)this.EmailMessageFactory.Make(EmailMessageType.NewAccount);
 
-				return Mapper.Map(user, new UserSummary());				
+                newAccountEmailMessage.ToRecipients.Add(signUpViewModel.NewUserEmailAddress);
+                this.EmailSender.Send(newAccountEmailMessage);
+
+                return Mapper.Map(user, new UserSummary());				
 			}
 		}
 
@@ -517,8 +521,14 @@ namespace Brewgr.Web.Controllers
 
 					userId = newUser.UserId;
 
-					// Track the Login
-					using (var unitOfWork = this.UnitOfWorkFactory.NewUnitOfWork())
+                    // Send the Email Message
+                    var newAccountEmailMessage = (NewAccountEmailMessage)this.EmailMessageFactory.Make(EmailMessageType.NewAccount);
+
+                    newAccountEmailMessage.ToRecipients.Add(oAuthUserInfo.EmailAddress);
+                    this.EmailSender.Send(newAccountEmailMessage);
+
+                    // Track the Login
+                    using (var unitOfWork = this.UnitOfWorkFactory.NewUnitOfWork())
 					{
 						this.UserLoginService.TrackLogin(userId.Value);
 						unitOfWork.Commit();

--- a/Brewgr.Web/Email/DefaultEmailMessageFactory.cs
+++ b/Brewgr.Web/Email/DefaultEmailMessageFactory.cs
@@ -32,6 +32,9 @@ namespace Brewgr.Web.Email
 				case EmailMessageType.ContactForm:
 					return new ContactFormEmailMessage(this.WebSettings, this.UserHostAddressResolver);
 
+                case EmailMessageType.NewAccount:
+                    return new NewAccountEmailMessage(this.WebSettings);
+
 				default:
 					throw new InvalidOperationException("Dear compiler, please check yo self so I don't have to default");
 			}

--- a/Brewgr.Web/Email/EmailMessageType.cs
+++ b/Brewgr.Web/Email/EmailMessageType.cs
@@ -5,6 +5,7 @@ namespace Brewgr.Web.Email
 	public enum EmailMessageType
 	{
 		PasswordReset,
-		ContactForm
+		ContactForm,
+        NewAccount
 	}
 }

--- a/Brewgr.Web/Email/NewAccountEmailMessage.cs
+++ b/Brewgr.Web/Email/NewAccountEmailMessage.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Text;
+using ctorx.Core.Email;
+using Brewgr.Web.Core.Configuration;
+
+namespace Brewgr.Web.Email
+{
+    public class NewAccountEmailMessage : AbstractEmailMessage
+    {
+        readonly IWebSettings WebSettings;
+        string AuthToken;
+
+        /// <summary>
+		/// Franck The Tank
+		/// </summary>
+        public NewAccountEmailMessage(IWebSettings webSettings)
+        {
+            this.WebSettings = webSettings;
+
+            this.SenderAddress = webSettings.SenderAddress;
+            this.SenderDisplayName = webSettings.SenderDisplayName;
+            this.Subject = "Welcome to Brewgr.com";
+            this.FormatAsHtml = false;
+        }
+
+        /// <summary>
+		/// Sets the Auth Token
+		/// </summary>
+		/// <param name="authToken"></param>
+		public void SetAuthToken(string authToken)
+        {
+            this.AuthToken = authToken;
+        }
+
+        /// <summary>
+		/// Builds the message body
+		/// </summary>
+		public override string BuildMessageBody()
+        {
+            var message = new StringBuilder();
+            
+            message.AppendLine("Welcome to Brewgr!");
+            message.AppendLine();
+            message.AppendLine("We're glad that you've signed up.  You've just joined a growing community of homebrewers with tons of recipes.  If you haven't already picked a username, you can do so by navigating to:");
+            message.AppendLine();
+            message.AppendFormat("<{0}/settings>", this.WebSettings.RootPathSecure);
+            message.AppendLine();
+            message.AppendLine();
+            message.AppendLine("If clicking the link above does not work, copy and paste the URL in a new browser window instead.");
+            message.AppendLine();
+            message.AppendLine("This is an automatically generated message. Replies are not monitored or answered.");
+            message.AppendLine();
+            message.AppendLine("Happy Brewing,");
+            message.AppendLine("The Brewgr Team");
+
+
+            return message.ToString();
+        }
+    }
+}


### PR DESCRIPTION
A email is now sent when a new user is created, wheter it is via
Facebook, or the Sign Up Form.